### PR TITLE
minimal pom validation

### DIFF
--- a/src/main/java/com/csoft/MainMojo.java
+++ b/src/main/java/com/csoft/MainMojo.java
@@ -4,6 +4,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.License;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -88,6 +89,7 @@ public class MainMojo extends AbstractMojo {
         Set<Artifact> transitiveDependencies = project.getArtifacts();
         transitiveDependencies.removeAll(project.getDependencyArtifacts());
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
 
         try {
             for (Artifact artifact : transitiveDependencies) {


### PR DESCRIPTION
Use minimal pom validation to avoid the status field check for distributionManagement. This field can be set by Maven on the distributed pom (e.g. Maven central) it seems, but should not be present in a project pom. To quote the Maven documentation:
> Warning! Like a baby bird in a nest, the status should never be touched by human hands!

[ERROR] Failed to execute goal com.github.carlomorelli:licensescan-maven-plugin:1.1:audit (default) on project my-project: Error while building project: Some problems were encountered while processing the POMs:
[ERROR] [ERROR] 'distributionManagement.status' must not be specified. @ line 36, column 13: 1 problem was encountered while building the effective model for xml-resolver:xml-resolver:1.2
[ERROR] [ERROR] 'distributionManagement.status' must not be specified. @ line 36, column 13

xml-resolver pom on maven central:
<distributionManagement><status>deployed</status></distributionManagement>

Validation code:
https://github.com/apache/maven/blob/b8c06e61ab73cd9e25a5b2c93d9e5077b2196751/maven-model-builder/src/main/java/org/apache/maven/model/validation/DefaultModelValidator.java#L447