### PR TITLE
add support for regex. issue #4

### DIFF
--- a/src/main/java/com/csoft/MainMojo.java
+++ b/src/main/java/com/csoft/MainMojo.java
@@ -15,6 +15,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.*;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 
 @Mojo(
@@ -138,10 +139,11 @@ public class MainMojo extends AbstractMojo {
                         if (printLicenses) {
                             getLog().info("   with license: " + license.getName());
                         }
-                        if (blacklistedMap.keySet().contains(license.getName())) {
-                            List<String> array = blacklistedMap.get(license.getName());
+                        Match forbiddenMatch = isForbiddenLicense(license);
+                        if (forbiddenMatch.isMatch) {
+                            List<String> array = blacklistedMap.get(forbiddenMatch.licenseEntry);
                             array.add(artifactLabel);
-                            blacklistedMap.put(license.getName(), array);
+                            blacklistedMap.put(forbiddenMatch.licenseEntry, array);
                             getLog().warn("WARNING: found blacklisted license");
                         }
                     }
@@ -149,6 +151,35 @@ public class MainMojo extends AbstractMojo {
             }
         } catch (ProjectBuildingException e) {
             throw new MojoExecutionException("Error while building project", e);
+        }
+    }
+
+    private Match isForbiddenLicense(License license) {
+        for(String entry : blacklistedMap.keySet()){
+            if(entry.startsWith("regex:")){
+                Pattern p = Pattern.compile(entry.replace("regex:",""));
+                if(p.matcher(license.getName()).find()){
+                    return new Match(entry);
+                }
+            } else if (entry.equalsIgnoreCase(license.getName())) {
+                return new Match(entry);
+            }
+        }
+        return new Match();
+    }
+
+    private class Match {
+        final boolean isMatch;
+        final String licenseEntry;
+
+        Match(){
+            this.isMatch = false;
+            this.licenseEntry = null;
+        }
+
+        Match(String licenseEntry){
+            this.isMatch = true;
+            this.licenseEntry = licenseEntry;
         }
     }
 

--- a/src/test/java/mocks/TestLog.java
+++ b/src/test/java/mocks/TestLog.java
@@ -48,7 +48,17 @@ public class TestLog extends SystemStreamLog {
                 return;
             }
         }
-        fail("No log line level: " + level + " message: " + mssg);
+        fail("No log line level: " + level + " message: " + mssg + "\n but found:" + getLevelMessages(level));
+    }
+
+    private String getLevelMessages(String level) {
+        StringBuffer buffer = new StringBuffer();
+        for(LogRow l : logs){
+            if(l.level.equals(level)){
+                buffer.append("\n").append("[").append(level).append("] ").append(l.mssg);
+            }
+        }
+        return buffer.toString();
     }
 
     private class LogRow {

--- a/src/test/projects/basic/pom.xml
+++ b/src/test/projects/basic/pom.xml
@@ -40,6 +40,7 @@
                     <blacklistedLicenses>
                         <license>Banned License v1</license>
                         <license>Banned License v2</license>
+                        <license>regex:Apache.*Version 1.*</license>
                     </blacklistedLicenses>
                     <failBuildOnBlacklisted>true</failBuildOnBlacklisted>
                 </configuration>


### PR DESCRIPTION
This adds regex support, which can be triggered by prepending "regex:" to the black list string. Totally open to doing this a different way. I also made the literal license check ignore case which I think you would always want.