### PR TITLE
Fix bundle packages and override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ hs_err_pid*
 **/.idea/*
 *.iml
 .DS_Store
+/bin/
+
+/.project
+/.classpath
+/.settings/org.eclipse.jdt.core.prefs
+/.settings/org.eclipse.jdt.ui.prefs

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Plugin configuration example in a project:
       </blacklistedLicenses>
       <failBuildOnBlacklisted>true</failBuildOnBlacklisted>
       <processPlugins>false</processPlugins>
-			<resolveDependencies>false</resolveDependencies>
-			<overruleOnNotBlacklisted>true</overruleOnNotBlacklisted>
+      <resolveDependencies>false</resolveDependencies>
+      <overruleOnNotBlacklisted>true</overruleOnNotBlacklisted>
     </configuration>
     <executions>
       <execution>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The following configuration parameters are offered:
 * `printLicenses`: prints the scanned licenses during the build (default `false`)
 * `blacklistedLicenses`: list of licenses that will make the build fail if detected
 * `failBuildOnBlacklisted`: if `blacklistedLicenses` are configured and at least a violation is found, makes the build fail (default `false`)
+* `processPlugins`: forces full lifecycle binding injection during the build: N.B. ensure this is set to `false` for `bundle` packages (default `false`)
+* `resolveDependencies`: resolves artefact dependencies during the build (default `false`)
+* `overruleOnNotBlacklisted`: causes the existence of a single permitted license for an artefact to override the existence of blacklisted licenses for the same artefact (e.g. logback) (default `true`)
 
 Parameter list `blacklistedLicenses` is tricky to configure as some Maven artifacts use different names (e.g. Apache 2.0, Apache Apache License, Version 2.0, Apache Version 2.0, etc...) for the same license.
 For this reason the plugin supports Regex expressions. You can define a regex for a license by prefixing the string with "regex:" like this:
@@ -36,6 +39,9 @@ Plugin configuration example in a project:
         <license>.*Affero.*</license>
       </blacklistedLicenses>
       <failBuildOnBlacklisted>true</failBuildOnBlacklisted>
+      <processPlugins>false</processPlugins>
+			<resolveDependencies>false</resolveDependencies>
+			<overruleOnNotBlacklisted>true</overruleOnNotBlacklisted>
     </configuration>
     <executions>
       <execution>

--- a/src/main/java/com/csoft/MainMojo.java
+++ b/src/main/java/com/csoft/MainMojo.java
@@ -1,5 +1,13 @@
 package com.csoft;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Pattern;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.License;
@@ -12,23 +20,19 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.*;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
 
-import java.util.*;
-import java.util.regex.Pattern;
-
-
-@Mojo(
-        name = "audit",
-        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
-)
+@Mojo(name = "audit", requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class MainMojo extends AbstractMojo {
 
-    @Parameter(defaultValue="${project}", readonly=true, required=true)
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
-    @Parameter(defaultValue="${session}", readonly=true, required=true)
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
     private MavenSession session;
 
     @Component
@@ -43,9 +47,18 @@ public class MainMojo extends AbstractMojo {
     @Parameter(property = "failBuildOnBlacklisted", defaultValue = "false")
     private boolean failBuildOnBlacklisted;
 
+    @Parameter(property = "resolveDependencies", defaultValue = "false")
+    private boolean resolveDependencies;
+
+    @Parameter(property = "processPlugins", defaultValue = "false")
+    private boolean processPlugins;
+
+    @Parameter(property = "overruleOnNotBlacklisted", defaultValue = "true")
+    private boolean overruleOnNotBlacklisted;
+
     private final Map<String, List<String>> blacklistedMap = new HashMap<String, List<String>>();
 
-    public MainMojo(){
+    public MainMojo() {
 
     }
 
@@ -69,6 +82,18 @@ public class MainMojo extends AbstractMojo {
         this.failBuildOnBlacklisted = failBuildOnBlacklisted;
     }
 
+    public void setResolveDependencies(boolean resolveDependencies) {
+        this.resolveDependencies = resolveDependencies;
+    }
+
+    public void setProcessPlugins(boolean processPlugins) {
+        this.processPlugins = processPlugins;
+    }
+
+    public void setOverruleOnNotBlacklisted(boolean overruleOnNotBlacklisted) {
+        this.overruleOnNotBlacklisted = overruleOnNotBlacklisted;
+    }
+
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         if (!blacklistedLicenses.isEmpty()) {
@@ -76,7 +101,6 @@ public class MainMojo extends AbstractMojo {
                 blacklistedMap.put(blacklistedLicense, new ArrayList<String>());
             }
         }
-
 
         getLog().info("Found project: " + project);
         getLog().info(" - artifactId          : " + project.getArtifactId());
@@ -91,6 +115,7 @@ public class MainMojo extends AbstractMojo {
 
         getLog().info("BASE DEPENDENCIES");
         getLog().info("-----------------------");
+
         analyze(project.getDependencyArtifacts());
 
         getLog().info("");
@@ -108,7 +133,7 @@ public class MainMojo extends AbstractMojo {
             for (String blacklistedLicense : blacklistedLicenses) {
                 List<String> array = blacklistedMap.get(blacklistedLicense);
                 if (!array.isEmpty()) {
-                    getLog().warn("Found " + array.size() + " violations for license '" + blacklistedLicense +"':");
+                    getLog().warn("Found " + array.size() + " violations for license '" + blacklistedLicense + "':");
                     for (String artifact : array) {
                         getLog().warn(" - " + artifact);
                     }
@@ -125,26 +150,69 @@ public class MainMojo extends AbstractMojo {
     private void analyze(Set<Artifact> transitiveDependencies) throws MojoExecutionException {
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
         buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+        buildingRequest.setResolveDependencies(this.resolveDependencies);
+        buildingRequest.setProcessPlugins(this.processPlugins);
 
         try {
             for (Artifact artifact : transitiveDependencies) {
-                String artifactLabel = artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion() + ":" + artifact.getScope();
+                String artifactLabel = artifact.getGroupId() + ":" + artifact.getArtifactId() + ":"
+                        + artifact.getVersion() + ":" + artifact.getScope();
                 getLog().info(" - artifact " + artifactLabel);
                 buildingRequest.setProject(null);
                 MavenProject mavenProject = projectBuilder.build(artifact, buildingRequest).getProject();
+                /*
+                 * each non-blacklisted license will be treated as permissive
+                 */
+                boolean permissiveLicenseFound = false;
+                /*
+                 * temporary map to hold blacklist information per artifact, as we can ignore it
+                 * or retain it, depending on the configuration
+                 */
+                Map<String, List<String>> blacklistedForArtifact = new HashMap<String, List<String>>();
+
                 if (printLicenses && mavenProject.getLicenses().isEmpty()) {
                     getLog().info("   with license: n/a");
                 } else {
+                    /*
+                     * if overruleOnNotBlacklisted=true, then, for artifacts that are released under
+                     * multiple licenses, the detection of a single non-blacklisted license will be
+                     * deemed sufficient to allow this artifact
+                     */
                     for (License license : mavenProject.getLicenses()) {
                         if (printLicenses) {
                             getLog().info("   with license: " + license.getName());
                         }
                         Match forbiddenMatch = isForbiddenLicense(license);
+
                         if (forbiddenMatch.isMatch) {
-                            List<String> array = blacklistedMap.get(forbiddenMatch.licenseEntry);
-                            array.add(artifactLabel);
-                            blacklistedMap.put(forbiddenMatch.licenseEntry, array);
-                            getLog().warn("WARNING: found blacklisted license");
+                            addToBlacklistMap(artifactLabel,
+                                    this.overruleOnNotBlacklisted ? blacklistedForArtifact : blacklistedMap,
+                                    forbiddenMatch);
+                        } else {
+                            if (this.overruleOnNotBlacklisted) {
+                                /*
+                                 * non-blacklisted license has been detected
+                                 */
+                                permissiveLicenseFound = true;
+                            }
+                        }
+                    }
+                    if (this.overruleOnNotBlacklisted) {
+                        if (permissiveLicenseFound) {
+                            /*
+                             * ignore blacklisted licenses as we have at least one that is allowed
+                             */
+                            if (isMapNonTrivial(blacklistedForArtifact)) {
+                                getLog().info("   blacklisting has been overridden");
+                            }
+                        } else {
+                            /*
+                             * nothing should be ignored so add all blacklisted licenses back in to main map
+                             */
+                            for (Entry<String, List<String>> entry : blacklistedForArtifact.entrySet()) {
+                                List<String> array = blacklistedForArtifact.get(entry.getKey());
+                                blacklistedMap.put(entry.getKey(), array);
+                            }
                         }
                     }
                 }
@@ -154,11 +222,32 @@ public class MainMojo extends AbstractMojo {
         }
     }
 
+    private boolean isMapNonTrivial(Map<String, List<String>> blacklistedMap) {
+        for (List<String> v : blacklistedMap.values()) {
+            if (!v.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void addToBlacklistMap(String artifactLabel, Map<String, List<String>> blacklistedMap,
+            Match forbiddenMatch) {
+        if (!blacklistedMap.containsKey(forbiddenMatch.licenseEntry)) {
+            blacklistedMap.put(forbiddenMatch.licenseEntry, new ArrayList<String>());
+        }
+        List<String> array = blacklistedMap.get(forbiddenMatch.licenseEntry);
+        array.add(artifactLabel);
+        blacklistedMap.put(forbiddenMatch.licenseEntry, array);
+
+        getLog().warn("WARNING: found blacklisted license");
+    }
+
     private Match isForbiddenLicense(License license) {
-        for(String entry : blacklistedMap.keySet()){
-            if(entry.startsWith("regex:")){
-                Pattern p = Pattern.compile(entry.replace("regex:",""), Pattern.CASE_INSENSITIVE);
-                if(p.matcher(license.getName()).find()){
+        for (String entry : blacklistedMap.keySet()) {
+            if (entry.startsWith("regex:")) {
+                Pattern p = Pattern.compile(entry.replace("regex:", ""), Pattern.CASE_INSENSITIVE);
+                if (p.matcher(license.getName()).find()) {
                     return new Match(entry);
                 }
             } else if (entry.equalsIgnoreCase(license.getName())) {
@@ -172,12 +261,12 @@ public class MainMojo extends AbstractMojo {
         final boolean isMatch;
         final String licenseEntry;
 
-        Match(){
+        Match() {
             this.isMatch = false;
             this.licenseEntry = null;
         }
 
-        Match(String licenseEntry){
+        Match(String licenseEntry) {
             this.isMatch = true;
             this.licenseEntry = licenseEntry;
         }

--- a/src/test/java/com/csoft/IntegrationTest.java
+++ b/src/test/java/com/csoft/IntegrationTest.java
@@ -1,14 +1,15 @@
 package com.csoft;
 
-import io.takari.maven.testing.TestResources;
-import io.takari.maven.testing.executor.MavenRuntime;
-import io.takari.maven.testing.executor.MavenVersions;
-import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.File;
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
 @MavenVersions({"3.2.3", "3.2.5", "3.6.0"})
@@ -26,17 +27,27 @@ public class IntegrationTest {
     public void test_Success() throws Exception {
         File basedir = resources.getBasedir("integration_pass");
         System.out.println(basedir.getAbsolutePath());
-        maven.forProject(basedir)
-                .execute("licensescan:audit")
-                .assertErrorFreeLog();
+        maven.forProject(basedir).execute("licensescan:audit").assertErrorFreeLog();
     }
 
     @Test
     public void test_Fail() throws Exception {
         File basedir = resources.getBasedir("integration_fail");
         System.out.println(basedir.getAbsolutePath());
-        maven.forProject(basedir)
-                .execute("licensescan:audit")
-                .assertLogText("[ERROR]");
+        maven.forProject(basedir).execute("licensescan:audit").assertLogText("[ERROR]");
+    }
+
+    @Test
+    public void test_Bundle_Success() throws Exception {
+        File basedir = resources.getBasedir("integration_bundle_pass");
+        System.out.println(basedir.getAbsolutePath());
+        maven.forProject(basedir).execute("licensescan:audit").assertErrorFreeLog();
+    }
+
+    @Test
+    public void test_Bundle_Fail() throws Exception {
+        File basedir = resources.getBasedir("integration_bundle_fail");
+        System.out.println(basedir.getAbsolutePath());
+        maven.forProject(basedir).execute("licensescan:audit").assertLogText("[ERROR]");
     }
 }

--- a/src/test/projects/integration_bundle_fail/pom.xml
+++ b/src/test/projects/integration_bundle_fail/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme.test.co</groupId>
+	<artifactId>test-project</artifactId>
+	<description>A nice test pom</description>
+	<packaging>jar</packaging>
+	<version>1</version>
+	<name>testing</name>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.2.5</version>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.carlomorelli</groupId>
+				<artifactId>licensescan-maven-plugin</artifactId>
+				<version>2.1</version>
+				<configuration>
+					<printLicenses>true</printLicenses>
+					<blacklistedLicenses>
+						<license>Banned License v1</license>
+						<license>Banned License v2</license>
+					</blacklistedLicenses>
+					<failBuildOnBlacklisted>true</failBuildOnBlacklisted>
+					<processPlugins>true</processPlugins>
+					<resolveDependencies>false</resolveDependencies>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+						<goals>
+							<goal>audit</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/test/projects/integration_bundle_pass/pom.xml
+++ b/src/test/projects/integration_bundle_pass/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme.test.co</groupId>
+	<artifactId>test-project</artifactId>
+	<description>A nice test pom</description>
+	<packaging>jar</packaging>
+	<version>1</version>
+	<name>testing</name>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.2.5</version>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.carlomorelli</groupId>
+				<artifactId>licensescan-maven-plugin</artifactId>
+				<version>2.1</version>
+				<configuration>
+					<printLicenses>true</printLicenses>
+					<blacklistedLicenses>
+						<license>Banned License v1</license>
+						<license>Banned License v2</license>
+					</blacklistedLicenses>
+					<failBuildOnBlacklisted>true</failBuildOnBlacklisted>
+					<processPlugins>false</processPlugins>
+					<resolveDependencies>false</resolveDependencies>
+					<overruleOnNotBlacklisted>true</overruleOnNotBlacklisted>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+						<goals>
+							<goal>audit</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>


### PR DESCRIPTION
Three new properties have been added: two (processPlugins and resolveDependencies) are set to false by default to match the implementation in the license-maven-plugin, and to allow the processing of packages of type bundle, and the third (overruleOnNotBlacklisted) allows artefacts that have been released under multiple licenses (e.g. logback), to be accepted if at least one of these licenses has not been blacklisted.

This third property would also be one way of solving issue #3, albeit without using a whitelist.